### PR TITLE
Fix redshift query

### DIFF
--- a/blogs/getting_started_data_lineage_preview/extract_redshift_lineage.py
+++ b/blogs/getting_started_data_lineage_preview/extract_redshift_lineage.py
@@ -143,7 +143,7 @@ def extract_queries_and_post_lineage(
     LEFT JOIN (
         SELECT query_id, LISTAGG(RTRIM(text)) WITHIN GROUP (ORDER BY sequence) AS query_txt
         FROM sys_query_text
-        WHERE sequence < 320
+        WHERE sequence < 16
         GROUP BY query_id
     ) qt ON qh.query_id = qt.query_id
     -- to get table_id


### PR DESCRIPTION
*Issue #, if available:*
LISTAGG has varchar(max) that has 64K bytes limit. SYS_QUERY_TEXT which has text of the SQL query that is in 4000-character increments

*Description of changes:*
Reduce the sequence clause to 16 to comply with 64k size limit


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
